### PR TITLE
Implement support for variable class registration

### DIFF
--- a/src/app/plugins/register.plugin.ts
+++ b/src/app/plugins/register.plugin.ts
@@ -1,10 +1,10 @@
 import { Plugin } from '../../common/plugin';
-import { IContainer, IMessage, ChannelType } from '../../common/types';
+import { IContainer, IMessage, ChannelType, ClassType } from '../../common/types';
 
 export class RegisterPlugin extends Plugin {
   public name: string = 'Register Plugin';
   public description: string = 'Allows for you to register classes.';
-  public usage: string = 'register <class_name>';
+  public usage: string = 'register (all | category <class_type> | <class_name>...)';
   public permission: ChannelType = ChannelType.Bot;
 
   constructor(public container: IContainer) {
@@ -16,16 +16,35 @@ export class RegisterPlugin extends Plugin {
   }
 
   public async execute(message: IMessage, args?: string[]) {
-    const request = this.container.classService.buildRequest(message.author, args);
-    if (!request) {
-      message.reply('I was unable to build your request.');
-      return;
-    }
-    try {
-      const response = await this.container.classService.register(request);
-      message.reply(response);
-    } catch (e) {
-      message.reply(e);
+    // Do a singular request if args is null or this is a category request
+    if (!!!args ||
+        args.length === 2 &&
+        (args[1] === ClassType.CS || args[1] === ClassType.IT)) {
+      const request = this.container.classService.buildRequest( message.author, args);
+      if (!request) {
+        message.reply('I was unable to build your request.');
+        return;
+      }
+      try {
+        const response = await this.container.classService.register(request);
+        message.reply(response);
+      } catch (e) {
+        message.reply(e);
+      }
+    } else {
+      for (let i in args) {
+        const request = this.container.classService.buildRequest(message.author, [ args[i] ]);
+        if (!request) {
+          message.reply('I was unable to build your request.');
+          return;
+        }
+        try {
+          const response = await this.container.classService.register(request);
+          message.reply(response);
+        } catch (e) {
+          message.reply(e);
+        }
+      }
     }
   }
 }

--- a/src/app/plugins/register.plugin.ts
+++ b/src/app/plugins/register.plugin.ts
@@ -17,7 +17,7 @@ export class RegisterPlugin extends Plugin {
 
   public async execute(message: IMessage, args?: string[]) {
     // Do a singular request if args is null or this is a category request
-    if (!!!args ||
+    if (!args ||
         args.length === 2 &&
         (args[1] === ClassType.CS || args[1] === ClassType.IT)) {
       const request = this.container.classService.buildRequest( message.author, args);
@@ -32,8 +32,8 @@ export class RegisterPlugin extends Plugin {
         message.reply(e);
       }
     } else {
-      for (let i in args) {
-        const request = this.container.classService.buildRequest(message.author, [ args[i] ]);
+      for (let arg of args) {
+        const request = this.container.classService.buildRequest(message.author, [ arg ]);
         if (!request) {
           message.reply('I was unable to build your request.');
           return;

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -100,3 +100,10 @@ export enum RequestType {
   Channel = 'Channel',
   Category = 'Category',
 }
+
+export enum ClassResponseType {
+  InvalidName = 'InvalidName',
+  NotFound = 'NotFound',
+  Success = 'Success',
+  Error = 'Error',
+}


### PR DESCRIPTION
Note: This is my first PR and first time using TypeScript, so I'm open to criticism.

I wanted to be able to register for all my classes at once using a format like `/register class1 class2 class3`, so I tried to implement that. 

If invalid classes are provided among the arguments they will be reported to the user along with the classes that were successfully registered.

One thing I'm not sure about is constructing the response, mainly because I haven't worked with JS strings.