### PR TITLE
refactor report ToString, fix bugs

### DIFF
--- a/src/app/plugins/modreport.plugin.ts
+++ b/src/app/plugins/modreport.plugin.ts
@@ -57,7 +57,7 @@ export class ModReportPlugin extends Plugin {
 
   private async _handleAddReport(message: IMessage, user_handle: string, description?: string) {
     const rep = this._createReport(message, user_handle, description);
-    message.reply(this.container.modService.fileReport(rep));
+    message.reply(await this.container.modService.fileReport(rep));
   }
 
   private async _handleListReport(message: IMessage, user_handle: string) {

--- a/src/services/moderation.service.ts
+++ b/src/services/moderation.service.ts
@@ -128,8 +128,6 @@ export class ModService {
       reportId: await fileReportResult,
     });
 
-    console.log('warning: ' + report);
-
     this._sendModMessageToUser('A warning has been issued. ', report);
     return `User warned: ${Moderation.Helpers.serialiseReportForMessage(report)}`;
   }


### PR DESCRIPTION
* ban could crash bot if fails
* warning loses attachment during sendModMessage due to shallow copy
* adding report was not awaiting the response, leading to incomplete feedback