### PR TITLE
Zoom links now recorded in bot_logs

### DIFF
--- a/src/app/handlers/blacklist.handler.ts
+++ b/src/app/handlers/blacklist.handler.ts
@@ -26,6 +26,7 @@ export class BlacklistHandler implements IHandler {
       message.author.send(
         'Hey, we are currently not allowing for UCF Zoom links to be posted within the Discord.'
       );
+      this.container.messageService.sendBotReport(message);
       message.delete();
       return;
     }


### PR DESCRIPTION
Just added _this.container.messageService.sendBotReport(message);_ to have Zoom links recorded in #bot_logs. 