### PR TITLE
Send roles info through files instead msg.content

### DIFF
--- a/src/app/plugins/manageroles.plugin.ts
+++ b/src/app/plugins/manageroles.plugin.ts
@@ -58,7 +58,7 @@ export class ManageRolesPlugin extends Plugin {
       return acc;
     }, []);
 
-    const filename = this._writeDataToFile(rolesInfo);
+    const filename = await this._writeDataToFile(rolesInfo);
 
     message.reply('See attached. To update, send back a file with changes.', { files: [filename] });
   }
@@ -85,7 +85,7 @@ export class ManageRolesPlugin extends Plugin {
 
     const results = await Promise.all(roleInfos.map((r) => this._updateRole(r)));
 
-    message.reply(`Attached result file.`, { files: [this._writeDataToFile(results)] });
+    message.reply(`Attached result file.`, { files: [await this._writeDataToFile(results)] });
   }
 
   private async _updateRole(roleInfo: RoleInfo): Promise<RoleUpdateResult | undefined> {
@@ -125,10 +125,10 @@ export class ManageRolesPlugin extends Plugin {
   }
 
   /// returns filename
-  private _writeDataToFile(data: any): string {
+  private async _writeDataToFile(data: any): Promise<string> {
     const discrim = '' + Math.random();
     const filename = `/tmp/roles_info${discrim}.json`;
-    fs.writeFileSync(filename, JSON.stringify(data));
+    await fs.promises.writeFile(filename, JSON.stringify(data));
     return filename;
   }
 

--- a/src/app/plugins/manageroles.plugin.ts
+++ b/src/app/plugins/manageroles.plugin.ts
@@ -128,7 +128,9 @@ export class ManageRolesPlugin extends Plugin {
   private async _writeDataToFile(data: any): Promise<string> {
     const discrim = '' + Math.random();
     const filename = `/tmp/roles_info${discrim}.json`;
-    await fs.promises.writeFile(filename, JSON.stringify(data));
+    await fs.promises.writeFile(filename, JSON.stringify(data)).catch((err) => {
+      this.container.loggerService.error('While writing to ' + filename, err);
+    });
     return filename;
   }
 


### PR DESCRIPTION
Requires /tmp, so docker should be run with --tmpfs /tmp

Fixes #204