### PR TITLE
Fix User link in market list

### DIFF
--- a/src/app/plugins/marketplace.plugin.ts
+++ b/src/app/plugins/marketplace.plugin.ts
@@ -137,7 +137,7 @@ export class MarketPlacePlugin extends Plugin {
     }
 
     const user = msg.author;
-    item += '\n' + user; //adds user to end of listing.
+    item += '\n' + user.toString(); //adds user to end of listing.
 
     //Check if sold
     const hasTargetReaction = msg.reactions.find((r) => r.emoji.name === this._TARGET_REACTION);


### PR DESCRIPTION
Sometimes the plugin would create a clickable link to a user, and sometimes it would just show their ID. This should fix it